### PR TITLE
Bumped library versions to the latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,14 +3,14 @@ import de.heikoseeberger.sbtheader.license.Apache2_0
 enablePlugins(AutomateHeaderPlugin, GitVersioning, GitBranchPrompt)
 sbtPlugin := true
 
-git.baseVersion := "0.4.0"
+git.baseVersion := "0.5.0"
 organization := "de.knutwalker"
 
 name := "sbt-knutwalker"
 description := "Opinionated meta plugin for github based open source projects"
 
 licenses := List("Apache 2.0" → url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-headers := Map("scala" -> Apache2_0("2015 – 2016", "Paul Horn"))
+headers := Map("scala" -> Apache2_0("2015 – 2017", "Paul Horn"))
 
 scalacOptions ++= List(
   "-unchecked",
@@ -22,28 +22,28 @@ scalacOptions ++= List(
   "-target:jvm-1.6",
   "-encoding", "UTF-8")
 libraryDependencies ++= List(
-  "org.specs2"                 %% "specs2-core"               % "3.5"    % "test",
-  "org.specs2"                 %% "specs2-scalacheck"         % "3.5"    % "test",
-  "org.scalacheck"             %% "scalacheck"                % "1.12.2" % "test",
-  "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.1.1"  % "test",
-  "org.typelevel"              %% "scalaz-specs2"             % "0.4.0"  % "test"
+  "org.specs2"                 %% "specs2-core"               % "3.8.9"  % "test",
+  "org.specs2"                 %% "specs2-scalacheck"         % "3.8.9"  % "test",
+  "org.scalacheck"             %% "scalacheck"                % "1.5"    % "test",
+  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.4"  % "test",
+  "org.typelevel"              %% "scalaz-specs2"             % "0.5.0"  % "test"
     exclude("org.specs2", s"specs2-core${scalaBinaryVersion.value}")
     exclude("org.specs2", s"specs2-scalacheck${scalaBinaryVersion.value}"))
 
 
-addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "0.14.2")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "0.14.4")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"   % "0.6.1")
-addSbtPlugin("se.marcuslonnberg"  % "sbt-docker"      % "1.3.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"     % "0.5.4")
+addSbtPlugin("se.marcuslonnberg"  % "sbt-docker"      % "1.4.1")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"     % "0.6.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"         % "0.8.5")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "1.5.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.2.6")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "0.1.9")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-site"        % "1.0.0")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "1.8.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.2.21")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "0.1.14")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-site"        % "1.2.0")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.0.0")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.3")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.4")
 addSbtPlugin("io.spray"           % "sbt-revolver"    % "0.8.0")
 addSbtPlugin("org.tpolecat"       % "tut-plugin"      % "0.4.2")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.3.5")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.0")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"    % "1.1")
-addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.3.3")
+addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.4.0")

--- a/src/main/scala/de/knutwalker/sbt/Developer.scala
+++ b/src/main/scala/de/knutwalker/sbt/Developer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/Github.scala
+++ b/src/main/scala/de/knutwalker/sbt/Github.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/JavaVersion.scala
+++ b/src/main/scala/de/knutwalker/sbt/JavaVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KCode.scala
+++ b/src/main/scala/de/knutwalker/sbt/KCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KReleaseSteps.scala
+++ b/src/main/scala/de/knutwalker/sbt/KReleaseSteps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KSbtKeys.scala
+++ b/src/main/scala/de/knutwalker/sbt/KSbtKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KTut.scala
+++ b/src/main/scala/de/knutwalker/sbt/KTut.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ object KTut {
     vcs.add(relative) !! log
     val status = vcs.status.!!.trim
     if (status.nonEmpty) {
-      vcs.commit(message) ! log
+      vcs.commit(message, sign = true) ! log
       Some(file)
     } else {
       None

--- a/src/main/scala/de/knutwalker/sbt/ScalaMainVersion.scala
+++ b/src/main/scala/de/knutwalker/sbt/ScalaMainVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/VersionOrdering.scala
+++ b/src/main/scala/de/knutwalker/sbt/VersionOrdering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/DeveloperSpec.scala
+++ b/src/test/scala/DeveloperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/GithubSpec.scala
+++ b/src/test/scala/GithubSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/JavaVersionSpec.scala
+++ b/src/test/scala/JavaVersionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/ScalaMainVersionSpec.scala
+++ b/src/test/scala/ScalaMainVersionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/ScalacOptionsSpec.scala
+++ b/src/test/scala/ScalacOptionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR attempts to bump the versions to the latest, mainly needed to update https://github.com/knutwalker/akka-stream-json to Scala 2.12 and latest version of akka-http-client