### PR TITLE
Fixed incorrect flags which were being used for Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Further, these things are provided or simplified
 Add the folling to you `project/plugins.sbt`
 
 ```scala
-addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.5.0")
+addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.5.1")
 ```
 
 The following keys should be used to activate various features and simplicifications

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import de.heikoseeberger.sbtheader.license.Apache2_0
 enablePlugins(AutomateHeaderPlugin, GitVersioning, GitBranchPrompt)
 sbtPlugin := true
 
-git.baseVersion := "0.5.0"
+git.baseVersion := "0.5.1"
 organization := "de.knutwalker"
 
 name := "sbt-knutwalker"

--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -53,7 +53,8 @@ object KScalaFlags {
 
   private def flagsFor12 = Seq(
     "-Xlint:_",
-    "-Ywarn-infer-any"
+    "-Ywarn-infer-any",
+    "opt:l:project"
   )
 
   private def universalFlags = Seq(

--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -26,7 +26,8 @@ object KScalaFlags {
 
   private def scalacFlags(scala: ScalaMainVersion, experimental: Boolean) = {
     val specificFlags = scala match {
-      case Scala211 | Scala212 ⇒ flagsFor11
+      case Scala211 ⇒ flagsFor11
+      case Scala212 ⇒ flagsFor12
       case _ ⇒ flagsFor10
     }
     val otherFlags = if (experimental) experimentalFlags else Seq()
@@ -40,10 +41,17 @@ object KScalaFlags {
   private def flagsFor11 = Seq(
     "-Xlint:_",
     "-Yconst-opt",
-    "-Ywarn-infer-any"
+    "-Ywarn-infer-any",
+    "-Yclosure-elim"
     // unused reports are too aggressive, imho
     // "-Ywarn-unused",
     // "-Ywarn-unused-import"
+  )
+
+  private def flagsFor12 = Seq(
+    "-Xlint:_",
+    "-Yconst-opt",
+    "-Ywarn-infer-any"
   )
 
   private def universalFlags = Seq(
@@ -55,7 +63,6 @@ object KScalaFlags {
     "-unchecked",
     "-Xfatal-warnings",
     "-Xfuture",
-    "-Yclosure-elim",
     "-Ydead-code",
     "-Yno-adapted-args",
     "-Ywarn-adapted-args",

--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -35,14 +35,17 @@ object KScalaFlags {
   }
 
   private def flagsFor10 = Seq(
-    "-Xlint"
+    "-Xlint",
+    "-Yclosure-elim",
+    "-Ydead-code"
   )
 
   private def flagsFor11 = Seq(
     "-Xlint:_",
     "-Yconst-opt",
     "-Ywarn-infer-any",
-    "-Yclosure-elim"
+    "-Yclosure-elim",
+    "-Ydead-code"
     // unused reports are too aggressive, imho
     // "-Ywarn-unused",
     // "-Ywarn-unused-import"
@@ -50,7 +53,6 @@ object KScalaFlags {
 
   private def flagsFor12 = Seq(
     "-Xlint:_",
-    "-Yconst-opt",
     "-Ywarn-infer-any"
   )
 
@@ -63,7 +65,6 @@ object KScalaFlags {
     "-unchecked",
     "-Xfatal-warnings",
     "-Xfuture",
-    "-Ydead-code",
     "-Yno-adapted-args",
     "-Ywarn-adapted-args",
     "-Ywarn-dead-code",


### PR DESCRIPTION
Turns out a few of the compiler flags was incorrect for Scala 2.12 and some new optimization flags were added.

I used `publishLocal` to verify that this version works locally.

Note that before merging this, I would read http://www.scala-lang.org/news/2.12.0#new-optimizer, there are some flags (notably `-opt:l:project` and `-opt:l:classpath`) which you may want to add to `flagsFor12 `, however they have some limitations. `-opt:l:project` is what I would recommend adding to the `flagsFor12`, as the `-opt:l:classpath` option is dangerous when used in libraries rather than actual applications