### PR TITLE
Update -opt:l:project deprecated flag

### DIFF
--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -54,7 +54,7 @@ object KScalaFlags {
   private def flagsFor12 = Seq(
     "-Xlint:_",
     "-Ywarn-infer-any",
-    "-opt:l:project"
+    "-opt-inline-from:<sources>"
   )
 
   private def universalFlags = Seq(


### PR DESCRIPTION
This flag is now deprecated, see https://github.com/mdedetrich/scalajson/issues/43#issue-266765529 for more info

If you use sbt-knutwalker, you need to use this flag if you are using scala versions 2.13.x or greater