### PR TITLE
Update plugin to SBT 1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,18 @@
-import de.heikoseeberger.sbtheader.license.Apache2_0
 
 enablePlugins(AutomateHeaderPlugin, GitVersioning, GitBranchPrompt)
 sbtPlugin := true
 
+val sbtVersion_ = "1.1.0"
+sbtVersion := sbtVersion_
+crossSbtVersions := List(sbtVersion_)
+scalaVersion := "2.12.4"
 git.baseVersion := "0.5.1"
 organization := "de.knutwalker"
 
 name := "sbt-knutwalker"
 description := "Opinionated meta plugin for github based open source projects"
 
-licenses := List("Apache 2.0" → url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-headers := Map("scala" -> Apache2_0("2015 – 2017", "Paul Horn"))
+headerLicense := Some(HeaderLicense.ALv2("2015 - 2017", "Paul Horn"))
 
 scalacOptions ++= List(
   "-unchecked",
@@ -19,7 +21,6 @@ scalacOptions ++= List(
   "-Xfuture",
   "-Xfatal-warnings",
   "-language:_",
-  "-target:jvm-1.6",
   "-encoding", "UTF-8")
 libraryDependencies ++= List(
   "org.specs2"                 %% "specs2-core"               % "3.8.9"  % "test",
@@ -31,19 +32,19 @@ libraryDependencies ++= List(
     exclude("org.specs2", s"specs2-scalacheck${scalaBinaryVersion.value}"))
 
 
-addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "0.14.4")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"   % "0.6.1")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "0.14.6")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"   % "0.7.0")
 addSbtPlugin("se.marcuslonnberg"  % "sbt-docker"      % "1.4.1")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"     % "0.6.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-git"         % "0.8.5")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "1.8.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.2.21")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "0.1.14")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-site"        % "1.2.0")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.0.0")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.4")
-addSbtPlugin("io.spray"           % "sbt-revolver"    % "0.8.0")
-addSbtPlugin("org.tpolecat"       % "tut-plugin"      % "0.4.2")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.0")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"    % "1.1")
-addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.4.0")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"     % "0.6.2")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-git"         % "0.9.3")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "4.1.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.3.3")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "0.1.18")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-site"        % "1.3.1")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.1.0")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.7")
+addSbtPlugin("io.spray"           % "sbt-revolver"    % "0.9.1")
+addSbtPlugin("org.tpolecat"       % "tut-plugin"      % "0.6.2")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.1")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"    % "2.1")
+addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.4.1")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version = 1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("me.lessis"          % "bintray-sbt"  % "0.3.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-git"      % "0.8.5")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"   % "1.5.0")
+addSbtPlugin("org.foundweekends"  % "sbt-bintray" % "0.5.2")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-git"     % "0.9.3")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"  % "4.1.0")

--- a/src/main/scala/de/knutwalker/sbt/Developer.scala
+++ b/src/main/scala/de/knutwalker/sbt/Developer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/Github.scala
+++ b/src/main/scala/de/knutwalker/sbt/Github.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/JavaVersion.scala
+++ b/src/main/scala/de/knutwalker/sbt/JavaVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KCode.scala
+++ b/src/main/scala/de/knutwalker/sbt/KCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package de.knutwalker.sbt
 
-import de.heikoseeberger.sbtheader.license.Apache2_0
-import sbt.{ Project, State }
+import sbt.{Project, State}
 import sbtrelease.Version
 import com.typesafe.sbt.git.JGit
+import de.heikoseeberger.sbtheader.License
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense
 
 import scala.xml.{Node => XNode, NodeSeq => XNodeSeq}
-import scala.xml.transform.{ RuleTransformer, RewriteRule }
+import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 object KCode extends VersionOrdering {
   private[this] val removeScoverageFromPom = new RewriteRule {
@@ -35,12 +36,10 @@ object KCode extends VersionOrdering {
     new RuleTransformer(removeScoverageFromPom)
 
 
-  def headerConfig(year: Option[Int], maintainer: String) = {
+  def headerConfig(year: Option[Int], maintainer: String): Option[License] = {
     val thisYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
     val years = List(year.getOrElse(thisYear), thisYear).distinct.mkString(" – ")
-    Map("java"  -> Apache2_0(years, maintainer),
-        "scala" -> Apache2_0(years, maintainer),
-        "conf"  -> Apache2_0(years, maintainer, "#"))
+    Some(HeaderLicense.ALv2(years, maintainer))
   }
 
   def sbtDevelopers(sbtv: String, devs: Seq[Developer]): List[sbt.Developer] = {

--- a/src/main/scala/de/knutwalker/sbt/KReleaseSteps.scala
+++ b/src/main/scala/de/knutwalker/sbt/KReleaseSteps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ object KReleaseSteps {
   lazy val inquireVersions = ReleaseStep { st: State ⇒
     val extracted = Project.extract(st)
     val lastVer = extracted.get(KSbtKeys.latestVersionTag).getOrElse("0.0.0")
-    val bump = extracted.get(releaseVersionBump)
+    val (newState, bump) = extracted.runTask(releaseVersionBump, st)
     val suggestedVersion = Version(lastVer).map(_.withoutQualifier.bump(bump).string).getOrElse(versionFormatError)
     val releaseVersion = readVersion(suggestedVersion, "Release version [%s] : ")
-    st.put(ReleaseKeys.versions, (releaseVersion, releaseVersion))
+    newState.put(ReleaseKeys.versions, (releaseVersion, releaseVersion))
   }
 
   lazy val setReleaseVersion = ReleaseStep { st: State =>
@@ -43,12 +43,12 @@ object KReleaseSteps {
   }
 
   lazy val publishSignedArtifacts = ReleaseStep(
-    action = Command.process("publishSigned", _),
+    action = releaseStepCommand("publishSigned"),
     enableCrossBuild = true
   )
 
   lazy val releaseToCentral = ReleaseStep(
-    action = Command.process("sonatypeReleaseAll", _),
+    action = releaseStepCommand("sonatypeReleaseAll"),
     enableCrossBuild = true
   )
 

--- a/src/main/scala/de/knutwalker/sbt/KSbtKeys.scala
+++ b/src/main/scala/de/knutwalker/sbt/KSbtKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KSbtPlugin.scala
+++ b/src/main/scala/de/knutwalker/sbt/KSbtPlugin.scala
@@ -35,7 +35,7 @@ import sbtrelease.Version
 import sbtunidoc.{ScalaUnidocPlugin, UnidocKeys}
 import spray.revolver.RevolverPlugin.autoImport.{reStart, reStatus, reStop}
 import tut.TutPlugin.autoImport.{tut => tutKey, _}
-import _root_.tut.TutPlugin
+import tut.TutPlugin
 
 
 object KSbtPlugin extends AutoPlugin with UnidocKeys with GhpagesKeys {

--- a/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
+++ b/src/main/scala/de/knutwalker/sbt/KScalaFlags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/KTut.scala
+++ b/src/main/scala/de/knutwalker/sbt/KTut.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import sbtrelease.Vcs
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
+import scala.sys.process.ProcessLogger
 
 
 object KTut {
@@ -124,10 +125,11 @@ object KTut {
   } yield ff
 
   private def tryCommit(message: String, vcs: Vcs, file: File, relative: String, log: Logger): Option[File] = {
-    vcs.add(relative) !! log
+    val processLog = ProcessLogger(message => log.info(message))
+    vcs.add(relative) !! processLog
     val status = vcs.status.!!.trim
     if (status.nonEmpty) {
-      vcs.commit(message, sign = true) ! log
+      vcs.commit(message, sign = true) ! processLog
       Some(file)
     } else {
       None

--- a/src/main/scala/de/knutwalker/sbt/ScalaMainVersion.scala
+++ b/src/main/scala/de/knutwalker/sbt/ScalaMainVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/de/knutwalker/sbt/VersionOrdering.scala
+++ b/src/main/scala/de/knutwalker/sbt/VersionOrdering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 - 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This plugin updates sbt-knutwalker so that it works with SBT 1.x. Note that I tried to make it cross compile for sbt 0.13.x and 1.x however this wasn't really possible due to some plugins having breaking changes.

Most of the breakages were mechanical apart from sbt-header where the changes were more fundamental. I would recommend reading https://github.com/sbt/sbt-header#migrating-from-1x for more information